### PR TITLE
Alliance Pallet Docs and Naming

### DIFF
--- a/frame/alliance/README.md
+++ b/frame/alliance/README.md
@@ -1,74 +1,70 @@
 # Alliance Pallet
 
-The Alliance Pallet provides a DAO to form an industry group that does two main things:
+The Alliance Pallet provides a collective that curates a blacklist of accounts and URLs,
+presumably agreed by the voting members to be bad actors. The alliance
 
-- provide a set of ethics against bad behaviors.
-- provide recognition and influence for those teams that contribute something back to the ecosystem.
+- provides a set of ethics against bad behavior, and
+- provides recognition and influence for those teams that contribute something back to the
+  ecosystem.
 
 ## Overview
 
-The Alliance first needs to initialize the Founders with sudo permissions.
-After that, anyone with an approved identity and website can apply to become a Candidate. 
-Members will initiate a motion to determine whether a Candidate can join the Alliance or not. 
-The motion requires the approval of over 2/3 majority. 
-The Alliance can also maintain a blacklist list about accounts and websites. 
-Members can also vote to update the alliance's rule and make announcements.
+The network initializes the Alliance via a Root call. After that, anyone with an approved
+identity and website can apply to become a Candidate. Members will initiate a motion to
+determine whether a Candidate can join the Alliance or not. The motion requires the approval of
+the `MembershipManager` origin. The Alliance can also maintain a blacklist of accounts and
+websites. Members can also vote to update the Alliance's rule and make announcements.
 
 ### Terminology
 
-- Rule: The IPFS Hash of the Alliance Rule for the community to read
-  and the alliance members to enforce for the management. 
-
-- Announcement: An IPFS hash of some content that the Alliance want to announce.
-
-- Member: An account which is already in the group of the Alliance,
-  including three types: Founder, Fellow, Ally.
-  Member can also be kicked by super majority motion or retire by itself. 
-
-- Founder: An account who is initiated by sudo with normal voting rights for basic motions
-  and special veto rights for rule change and ally elevation motions.
-
-- Fellow: An account who is elevated from Ally by Founders and other Fellows from Ally.
-
-- Ally: An account who is approved by Founders and Fellows from Candidate.
-  An Ally doesn't have voting rights.
-
-- Candidate: An account who is trying to become a member.
-  The applicant should already have an approved identity with website.
-  The application should be submitted by the account itself with some token as deposit,
-  or be nominated by an existing Founder or Fellow for free.
-
-- Blacklist: A list of bad websites and addresses, and can be added or removed items by Founders and Fellows.
+- Rule: The IPFS CID (hash) of the Alliance rules for the community to read and the Alliance
+  members to enforce. Similar to a Code of Conduct.
+- Announcement: An IPFS CID of some content that the Alliance want to announce.
+- Member: An account that is already in the group of the Alliance, including three types:
+  Founder, Fellow, or Ally. A member can also be kicked by the `MembershipManager` origin or
+  retire by itself.
+- Founder: An account who is initiated by Root with normal voting rights for basic motions and
+  special veto rights for rule change and ally elevation motions.
+- Fellow: An account who is elevated from Ally by Founders and other Fellows.
+- Ally: An account who is approved by Founders and Fellows from Candidate. An Ally doesn't have
+  voting rights.
+- Candidate: An account who is trying to become a member. The applicant should already have an
+  approved identity with website. The application should be submitted by the account itself with
+  some deposit, or be nominated by an existing Founder or Fellow for free.
+- Blacklist: A list of bad websites and addresses, items can be added or removed by Founders
+  and Fellows.
 
 ## Interface
 
 ### Dispatchable Functions
 
 #### For General Users
+
 - `submit_candidacy` - Submit the application to become a candidate with deposit.
 
 #### For Members (All)
-- `retire` - Member retire to out of the Alliance and release its deposit.
 
-#### For Members (Founders/Fellows) 
+- `retire` - Retire from the Alliance and release the caller's deposit.
+
+#### For Members (Founders/Fellows)
 
 - `propose` - Propose a motion.
-- `vote` - Vote on a motion. 
-- `close` - Close a motion with enough votes or expired. 
-- `set_rule` - Initialize or update the alliance's rule by IPFS hash. 
-- `announce` - Make announcement by IPFS hash.
-- `nominate_candidacy` - Nominate a non-member to become a Candidate for free.
+- `vote` - Vote on a motion.
+- `close` - Close a motion with enough votes or that has expired.
+- `set_rule` - Initialize or update the Alliance's rule by IPFS CID.
+- `announce` - Make announcement by IPFS CID.
+- `nominate_candidate` - Nominate a non-member to become a Candidate for free.
 - `approve_candidate` - Approve a candidate to become an Ally.
 - `reject_candidate` - Reject a candidate and slash its deposit.
 - `elevate_ally` - Approve an ally to become a Fellow.
-- `kick_member` - Kick a member and slash its deposit. 
-- `add_blacklist` - Add some items of account and website in the blacklist.
-- `remove_blacklist` - Remove some items of account and website from the blacklist.
+- `kick_member` - Kick a member and slash its deposit.
+- `add_blacklist_items` - Add some items, either accounts or websites, to the blacklist.
+- `remove_blacklist_items` - Remove some items from the blacklist.
 
 #### For Members (Only Founders)
+
 - `veto` - Veto on a motion about `set_rule` and `elevate_ally`.
 
-#### For Super Users
-- `init_founders` - Initialize the founding members.
+#### Root Calls
 
-License: Apache-2.0
+- `init_founders` - Initialize the founding members.

--- a/frame/alliance/src/benchmarking.rs
+++ b/frame/alliance/src/benchmarking.rs
@@ -663,7 +663,7 @@ benchmarks_instance_pallet! {
 		}.into());
 	}
 
-	nominate_candidacy {
+	nominate_candidate {
 		set_members::<T, I>();
 
 		let founder1 = founder::<T, I>(1);
@@ -785,7 +785,7 @@ benchmarks_instance_pallet! {
 		}.into());
 	}
 
-	add_blacklist {
+	add_blacklist_items {
 		let n in 1 .. T::MaxBlacklistCount::get();
 		let l in 1 .. T::MaxWebsiteUrlLength::get();
 
@@ -800,14 +800,14 @@ benchmarks_instance_pallet! {
 		blacklist.extend(accounts.into_iter().map(BlacklistItem::AccountId));
 		blacklist.extend(websites.into_iter().map(BlacklistItem::Website));
 
-		let call = Call::<T, I>::add_blacklist { infos: blacklist.clone() };
+		let call = Call::<T, I>::add_blacklist_items { infos: blacklist.clone() };
 		let origin = T::SuperMajorityOrigin::successful_origin();
 	}: { call.dispatch_bypass_filter(origin)? }
 	verify {
 		assert_last_event::<T, I>(Event::BlacklistAdded { items: blacklist }.into());
 	}
 
-	remove_blacklist {
+	remove_blacklist_items {
 		let n in 1 .. T::MaxBlacklistCount::get();
 		let l in 1 .. T::MaxWebsiteUrlLength::get();
 
@@ -828,7 +828,7 @@ benchmarks_instance_pallet! {
 		blacklist.extend(accounts.into_iter().map(BlacklistItem::AccountId));
 		blacklist.extend(websites.into_iter().map(BlacklistItem::Website));
 
-		let call = Call::<T, I>::remove_blacklist { infos: blacklist.clone() };
+		let call = Call::<T, I>::remove_blacklist_items { infos: blacklist.clone() };
 		let origin = T::SuperMajorityOrigin::successful_origin();
 	}: { call.dispatch_bypass_filter(origin)? }
 	verify {

--- a/frame/alliance/src/lib.rs
+++ b/frame/alliance/src/lib.rs
@@ -17,44 +17,39 @@
 
 //! # Alliance Pallet
 //!
-//! The Alliance Pallet provides a DAO to form an industry group that does two main things:
+//! The Alliance Pallet provides a collective that curates a blacklist of accounts and URLs,
+//! presumably agreed by the voting members to be bad actors. The alliance
 //!
-//! - provide a set of ethics against bad behaviors.
-//! - provide recognition and influence for those teams that contribute something back to the
+//! - provides a set of ethics against bad behavior, and
+//! - provides recognition and influence for those teams that contribute something back to the
 //!   ecosystem.
 //!
 //! ## Overview
 //!
-//! The Alliance first needs to initialize the Founders with sudo permissions.
+//! The network initializes the Alliance via a Root call.
 //! After that, anyone with an approved identity and website can apply to become a Candidate.
 //! Members will initiate a motion to determine whether a Candidate can join the Alliance or not.
-//! The motion requires the approval of over 2/3 majority.
-//! The Alliance can also maintain a blacklist list about accounts and websites.
-//! Members can also vote to update the alliance's rule and make announcements.
+//! The motion requires the approval of the `SuperMajorityOrigin`.
+//! The Alliance can also maintain a blacklist of accounts and websites.
+//! Members can also vote to update the Alliance's rule and make announcements.
 //!
 //! ### Terminology
 //!
-//! - Rule: The IPFS Hash of the Alliance Rule for the community to read and the alliance members to
-//!   enforce for the management.
-//!
-//! - Announcement: An IPFS hash of some content that the Alliance want to announce.
-//!
-//! - Member: An account which is already in the group of the Alliance, including three types:
-//!   Founder, Fellow, Ally. Member can also be kicked by super majority motion or retire by itself.
-//!
-//! - Founder: An account who is initiated by sudo with normal voting rights for basic motions and
+//! - Rule: The IPFS CID (hash) of the Alliance rules for the community to read and the Alliance
+//!   members to enforce. Similar to a Code of Conduct.
+//! - Announcement: An IPFS CID of some content that the Alliance want to announce.
+//! - Member: An account that is already in the group of the Alliance, including three types:
+//!   Founder, Fellow, or Ally. A member can also be kicked by `SuperMajorityOrigin` or retire by
+//!   itself.
+//! - Founder: An account who is initiated by Root with normal voting rights for basic motions and
 //!   special veto rights for rule change and ally elevation motions.
-//!
-//! - Fellow: An account who is elevated from Ally by Founders and other Fellows from Ally.
-//!
+//! - Fellow: An account who is elevated from Ally by Founders and other Fellows.
 //! - Ally: An account who is approved by Founders and Fellows from Candidate. An Ally doesn't have
 //!   voting rights.
-//!
 //! - Candidate: An account who is trying to become a member. The applicant should already have an
 //!   approved identity with website. The application should be submitted by the account itself with
-//!   some token as deposit, or be nominated by an existing Founder or Fellow for free.
-//!
-//! - Blacklist: A list of bad websites and addresses, and can be added or removed items by Founders
+//!   some deposit, or be nominated by an existing Founder or Fellow for free.
+//! - Blacklist: A list of bad websites and addresses, items can be added or removed by Founders
 //!   and Fellows.
 //!
 //! ## Interface
@@ -62,30 +57,34 @@
 //! ### Dispatchable Functions
 //!
 //! #### For General Users
+//!
 //! - `submit_candidacy` - Submit the application to become a candidate with deposit.
 //!
 //! #### For Members (All)
-//! - `retire` - Member retire to out of the Alliance and release its deposit.
+//!
+//! - `retire` - Retire from the Alliance and release the caller's deposit.
 //!
 //! #### For Members (Founders/Fellows)
 //!
 //! - `propose` - Propose a motion.
 //! - `vote` - Vote on a motion.
-//! - `close` - Close a motion with enough votes or expired.
-//! - `set_rule` - Initialize or update the alliance's rule by IPFS hash.
-//! - `announce` - Make announcement by IPFS hash.
+//! - `close` - Close a motion with enough votes or that has expired.
+//! - `set_rule` - Initialize or update the Alliance's rule by IPFS CID.
+//! - `announce` - Make announcement by IPFS CID.
 //! - `nominate_candidacy` - Nominate a non-member to become a Candidate for free.
 //! - `approve_candidate` - Approve a candidate to become an Ally.
 //! - `reject_candidate` - Reject a candidate and slash its deposit.
 //! - `elevate_ally` - Approve an ally to become a Fellow.
 //! - `kick_member` - Kick a member and slash its deposit.
-//! - `add_blacklist` - Add some items of account and website in the blacklist.
-//! - `remove_blacklist` - Remove some items of account and website from the blacklist.
+//! - `add_blacklist` - Add some items, either accounts or websites, to the blacklist.
+//! - `remove_blacklist` - Remove some items from the blacklist.
 //!
 //! #### For Members (Only Founders)
+//!
 //! - `veto` - Veto on a motion about `set_rule` and `elevate_ally`.
 //!
-//! #### For Super Users
+//! #### Root Calls
+//!
 //! - `init_founders` - Initialize the founding members.
 
 #![cfg_attr(not(feature = "std"), no_std)]
@@ -188,7 +187,7 @@ pub trait ProposalProvider<AccountId, Hash, Proposal> {
 	fn proposal_of(proposal_hash: Hash) -> Option<Proposal>;
 }
 
-/// The role of members.
+/// The various roles that a member can hold.
 #[derive(Copy, Clone, PartialEq, Eq, RuntimeDebug, Encode, Decode, TypeInfo, MaxEncodedLen)]
 pub enum MemberRole {
 	Founder,
@@ -196,7 +195,7 @@ pub enum MemberRole {
 	Ally,
 }
 
-/// The item type of blacklist.
+/// The type of item within the blacklist.
 #[derive(Clone, PartialEq, Eq, RuntimeDebug, Encode, Decode, TypeInfo, MaxEncodedLen)]
 pub enum BlacklistItem<AccountId, Url> {
 	AccountId(AccountId),
@@ -227,8 +226,7 @@ pub mod pallet {
 			+ IsSubType<Call<Self, I>>
 			+ IsType<<Self as frame_system::Config>::Call>;
 
-		/// Origin from which the next tabled referendum may be forced; this allows for the tabling
-		/// of a majority-carries referendum.
+		/// TO RENAME
 		type SuperMajorityOrigin: EnsureOrigin<Self::Origin>;
 
 		/// The currency used for deposits.
@@ -237,13 +235,13 @@ pub mod pallet {
 		/// What to do with slashed funds.
 		type Slashed: OnUnbalanced<NegativeImbalanceOf<Self, I>>;
 
-		/// What to do with genesis voteable members
+		/// What to do with initial voting members of the Alliance.
 		type InitializeMembers: InitializeMembers<Self::AccountId>;
 
-		/// The receiver of the signal for when the voteable members have changed.
+		/// What to do when a member has been added or removed.
 		type MembershipChanged: ChangeMembers<Self::AccountId>;
 
-		/// The identity verifier of alliance member.
+		/// The identity verifier of an Alliance member.
 		type IdentityVerifier: IdentityVerifier<Self::AccountId>;
 
 		/// The provider of the proposal operation.
@@ -256,44 +254,44 @@ pub mod pallet {
 		///
 		/// NOTE:
 		/// + Benchmarks will need to be re-run and weights adjusted if this changes.
-		/// + This pallet assumes that dependents keep to the limit without enforcing it.
+		/// + This pallet assumes that dependencies keep to the limit without enforcing it.
 		type MaxFounders: Get<u32>;
 
 		/// The maximum number of fellows supported by the pallet. Used for weight estimation.
 		///
 		/// NOTE:
 		/// + Benchmarks will need to be re-run and weights adjusted if this changes.
-		/// + This pallet assumes that dependents keep to the limit without enforcing it.
+		/// + This pallet assumes that dependencies keep to the limit without enforcing it.
 		type MaxFellows: Get<u32>;
 
 		/// The maximum number of allies supported by the pallet. Used for weight estimation.
 		///
 		/// NOTE:
 		/// + Benchmarks will need to be re-run and weights adjusted if this changes.
-		/// + This pallet assumes that dependents keep to the limit without enforcing it.
+		/// + This pallet assumes that dependencies keep to the limit without enforcing it.
 		type MaxAllies: Get<u32>;
 
-		/// The maximum number of blacklist supported by the pallet.
+		/// The maximum length of the blacklist supported by the pallet.
 		#[pallet::constant]
 		type MaxBlacklistCount: Get<u32>;
 
-		/// The maximum length of website url.
+		/// The maximum length of a website URL.
 		#[pallet::constant]
 		type MaxWebsiteUrlLength: Get<u32>;
 
-		/// The amount of a deposit required for submitting candidacy.
+		/// The deposit required for submitting candidacy.
 		#[pallet::constant]
 		type CandidateDeposit: Get<BalanceOf<Self, I>>;
 
-		/// The maximum numbers of announcements.
+		/// The maximum number of announcements.
 		#[pallet::constant]
 		type MaxAnnouncementsCount: Get<u32>;
 
-		/// The maximum numbers of members per member role.
+		/// The maximum number of members per member role.
 		#[pallet::constant]
 		type MaxMembersCount: Get<u32>;
 
-		/// The maximum numbers of candidates.
+		/// The maximum number of candidates.
 		#[pallet::constant]
 		type MaxCandidatesCount: Get<u32>;
 
@@ -305,37 +303,37 @@ pub mod pallet {
 	pub enum Error<T, I = ()> {
 		/// The founders/fellows/allies have already been initialized.
 		MembersAlreadyInitialized,
-		/// Already be a candidate.
+		/// Account is already a candidate.
 		AlreadyCandidate,
-		/// Not be a candidate.
+		/// Account is not a candidate.
 		NotCandidate,
-		/// Already be a member.
+		/// Account is already a member.
 		AlreadyMember,
-		/// Not be a member.
+		/// Account is not a member.
 		NotMember,
-		/// Not be an ally member.
+		/// Account is not an ally.
 		NotAlly,
-		/// Not be a founder member.
+		/// Account is not a founder.
 		NotFounder,
-		/// Not be a kicking member.
+		/// TO RENAME
 		NotKickingMember,
-		/// Not be a votable (founder or fellow) member.
+		/// Account does not have voting rights.
 		NotVotableMember,
-		/// Already be an elevated (fellow) member.
+		/// Account is already an elevated (fellow) member.
 		AlreadyElevated,
-		/// Already be a blacklist item.
+		/// Item is already in the blacklist.
 		AlreadyInBlacklist,
-		/// Not be a blacklist item.
+		/// Item is not blacklisted.
 		NotInBlacklist,
-		/// Number of blacklist exceed MaxBlacklist.
+		/// Length of blacklist exceeds `MaxBlacklist`.
 		TooManyBlacklist,
-		/// Length of website url exceed MaxWebsiteUrlLength.
+		/// Length of website URL exceeds `MaxWebsiteUrlLength`.
 		TooLongWebsiteUrl,
-		/// The member is kicking.
+		/// TO RENAME
 		KickingMember,
 		/// Balance is insufficient to be a candidate.
 		InsufficientCandidateFunds,
-		/// The account's identity has not display field and website field.
+		/// The account's identity does not have display field and website field.
 		WithoutIdentityDisplayAndWebsite,
 		/// The account's identity has no good judgement.
 		WithoutGoodIdentityJudgement,
@@ -343,50 +341,50 @@ pub mod pallet {
 		MissingProposalHash,
 		/// The proposal is not vetoable.
 		NotVetoableProposal,
-		/// The Announcement is not found.
+		/// The announcement is not found.
 		MissingAnnouncement,
-		/// Number of members exceed MaxMembersCount.
+		/// Number of members exceeds `MaxMembersCount`.
 		TooManyMembers,
-		/// Number of candidates exceed MaxCandidatesCount.
+		/// Number of candidates exceeds `MaxCandidatesCount`.
 		TooManyCandidates,
-		/// Number of Announcements exceed MaxAnnouncementsCount.
+		/// Number of announcements exceeds `MaxAnnouncementsCount`.
 		TooManyAnnouncements,
 	}
 
 	#[pallet::event]
 	#[pallet::generate_deposit(pub(super) fn deposit_event)]
 	pub enum Event<T: Config<I>, I: 'static = ()> {
-		/// A new rule has been set.
+		/// A new rule has been set. // TO RENAME
 		NewRule { rule: Cid },
 		/// A new announcement has been proposed.
 		NewAnnouncement { announcement: Cid },
-		/// A on-chain announcement has been removed.
+		/// An on-chain announcement has been removed.
 		AnnouncementRemoved { announcement: Cid },
-		/// Some accounts have been initialized to members (founders/fellows/allies).
+		/// Some accounts have been initialized as members (founders/fellows/allies).
 		MembersInitialized {
 			founders: Vec<T::AccountId>,
 			fellows: Vec<T::AccountId>,
 			allies: Vec<T::AccountId>,
 		},
-		/// An account has been added as a candidate and lock its deposit.
+		/// An account has been added as a candidate and reserved its deposit.
 		CandidateAdded {
 			candidate: T::AccountId,
 			nominator: Option<T::AccountId>,
 			reserved: Option<BalanceOf<T, I>>,
 		},
-		/// A proposal has been proposed to approve the candidate.
+		/// A candidate has been approved as an ally.
 		CandidateApproved { candidate: T::AccountId },
-		/// A proposal has been proposed to reject the candidate.
+		/// A candidate has been rejected and its deposit slashed.
 		CandidateRejected { candidate: T::AccountId },
-		/// As an active member, an ally has been elevated to fellow.
+		/// An ally has been elevated to fellow.
 		AllyElevated { ally: T::AccountId },
 		/// A member has retired to an ordinary account with its deposit unreserved.
 		MemberRetired { member: T::AccountId, unreserved: Option<BalanceOf<T, I>> },
 		/// A member has been kicked out to an ordinary account with its deposit slashed.
 		MemberKicked { member: T::AccountId, slashed: Option<BalanceOf<T, I>> },
-		/// Accounts or websites have been added into blacklist.
+		/// Accounts or websites have been added into the blacklist. // TO RENAME
 		BlacklistAdded { items: Vec<BlacklistItemOf<T, I>> },
-		/// Accounts or websites have been removed from blacklist.
+		/// Accounts or websites have been removed from the blacklist. // TO RENAME
 		BlacklistRemoved { items: Vec<BlacklistItemOf<T, I>> },
 	}
 
@@ -447,37 +445,34 @@ pub mod pallet {
 		}
 	}
 
-	/// The IPFS cid of the alliance rule.
-	/// Founders and fellows can propose a new rule, other founders and fellows make a traditional
-	/// super-majority votes, vote to determine if the rules take effect.
+	/// The IPFS CID of the alliance rule.
+	/// Founders and fellows can propose a new rule with a super-majority.
 	///
 	/// Any founder has a special one-vote veto right to the rule setting.
 	#[pallet::storage]
 	#[pallet::getter(fn rule)]
 	pub type Rule<T: Config<I>, I: 'static = ()> = StorageValue<_, Cid, OptionQuery>;
 
-	/// The current IPFS cids of the announcements.
+	/// The current IPFS CIDs of any announcements.
 	#[pallet::storage]
 	#[pallet::getter(fn announcements)]
 	pub type Announcements<T: Config<I>, I: 'static = ()> =
 		StorageValue<_, BoundedVec<Cid, T::MaxAnnouncementsCount>, ValueQuery>;
 
-	/// Maps member and their candidate deposit.
+	/// Maps members to their candidacy deposit.
 	#[pallet::storage]
 	#[pallet::getter(fn deposit_of)]
 	pub type DepositOf<T: Config<I>, I: 'static = ()> =
 		StorageMap<_, Blake2_128Concat, T::AccountId, BalanceOf<T, I>, OptionQuery>;
 
 	/// The current set of candidates.
-	/// If the candidacy is approved by a motion, then it will become an ally member.
+	/// If a candidate is approved by a motion, then it will become an ally.
 	#[pallet::storage]
 	#[pallet::getter(fn candidates)]
 	pub type Candidates<T: Config<I>, I: 'static = ()> =
 		StorageValue<_, BoundedVec<T::AccountId, T::MaxCandidatesCount>, ValueQuery>;
 
-	/// Maps member type to alliance members, including founder, fellow and ally.
-	/// Founders and fellows can propose and vote on alliance motions,
-	/// and ally can only wait to be elevated to fellow.
+	/// Maps member type to members of each type.
 	#[pallet::storage]
 	#[pallet::getter(fn members)]
 	pub type Members<T: Config<I>, I: 'static = ()> = StorageMap<
@@ -488,13 +483,13 @@ pub mod pallet {
 		ValueQuery,
 	>;
 
-	/// The members are being kicked out. They can't retire during the motion.
+	/// A set of members that are (potentially) being kicked out. They cannot retire until settled.
 	#[pallet::storage]
 	#[pallet::getter(fn kicking_member)]
 	pub type KickingMembers<T: Config<I>, I: 'static = ()> =
 		StorageMap<_, Blake2_128Concat, T::AccountId, bool, ValueQuery>;
 
-	/// The current blacklist of accounts. The accounts can't submit candidacy.
+	/// The current blacklist of accounts. These accounts cannot submit candidacy.
 	#[pallet::storage]
 	#[pallet::getter(fn account_blacklist)]
 	pub type AccountBlacklist<T: Config<I>, I: 'static = ()> =
@@ -510,7 +505,7 @@ pub mod pallet {
 	impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		/// Add a new proposal to be voted on.
 		///
-		/// Requires the sender to be founder or fellow.
+		/// Requires the sender to be a founder or fellow.
 		#[pallet::weight((
 			T::WeightInfo::propose_proposed(
 				*length_bound, // B
@@ -540,7 +535,7 @@ pub mod pallet {
 
 		/// Add an aye or nay vote for the sender to the given proposal.
 		///
-		/// Requires the sender to be founder or fellow.
+		/// Requires the sender to be a founder or fellow.
 		#[pallet::weight((
 			T::WeightInfo::vote(T::MaxFounders::get(), T::MaxFellows::get()),
 			DispatchClass::Operational
@@ -558,8 +553,8 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Disapprove a proposal about set_rule and elevate_ally, close, and remove it from
-		/// the system, regardless of its current state.
+		/// Veto a proposal about `set_rule` and `elevate_ally`, close, and remove it from the
+		/// system, regardless of its current state.
 		///
 		/// Must be called by a founder.
 		#[pallet::weight(T::WeightInfo::veto(T::MaxProposals::get()))]
@@ -578,9 +573,9 @@ pub mod pallet {
 			}
 		}
 
-		/// Close a vote that is either approved, disapproved or whose voting period has ended.
+		/// Close a vote that is either approved, disapproved, or whose voting period has ended.
 		///
-		/// Requires the sender to be founder or fellow.
+		/// Requires the sender to be a founder or fellow.
 		#[pallet::weight((
 			{
 				let b = *length_bound;
@@ -624,9 +619,9 @@ pub mod pallet {
 			Ok(info.into())
 		}
 
-		/// Initialize the founders/fellows/allies.
+		/// Initialize the founders, fellows, and allies.
 		///
-		/// This should only be called once.
+		/// This should only be called once, and must be called by the Root origin.
 		#[pallet::weight(T::WeightInfo::init_members(
 			T::MaxFounders::get(),
 			T::MaxFellows::get(),
@@ -685,7 +680,7 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Set a new IPFS cid to the alliance rule.
+		/// Set a new IPFS CID to the alliance rule.
 		#[pallet::weight(T::WeightInfo::set_rule())]
 		pub fn set_rule(origin: OriginFor<T>, rule: Cid) -> DispatchResult {
 			T::SuperMajorityOrigin::ensure_origin(origin)?;
@@ -696,7 +691,7 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Make a new announcement by a new IPFS cid about the alliance issues.
+		/// Make an announcement of a new IPFS CID about alliance issues.
 		#[pallet::weight(T::WeightInfo::announce())]
 		pub fn announce(origin: OriginFor<T>, announcement: Cid) -> DispatchResult {
 			T::SuperMajorityOrigin::ensure_origin(origin)?;
@@ -711,7 +706,7 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Remove the announcement.
+		/// Remove an announcement.
 		#[pallet::weight(T::WeightInfo::remove_announcement())]
 		pub fn remove_announcement(origin: OriginFor<T>, announcement: Cid) -> DispatchResult {
 			T::SuperMajorityOrigin::ensure_origin(origin)?;
@@ -728,7 +723,7 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Submit oneself for candidacy. A fixed amount of deposit is recorded.
+		/// Submit oneself for candidacy. A fixed deposit is reserved.
 		#[pallet::weight(T::WeightInfo::submit_candidacy())]
 		pub fn submit_candidacy(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -755,7 +750,7 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Founder or fellow can nominate someone to join the alliance and become a candidate.
+		/// A founder or fellow can nominate someone to join the alliance and become a candidate.
 		/// There is no deposit required to the nominator or nominee.
 		#[pallet::weight(T::WeightInfo::nominate_candidacy())]
 		pub fn nominate_candidacy(
@@ -801,7 +796,7 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Reject a `Candidate` back to an ordinary account.
+		/// Reject a `Candidate`. This results in a slash of the candidate's deposit.
 		#[pallet::weight(T::WeightInfo::reject_candidate())]
 		pub fn reject_candidate(
 			origin: OriginFor<T>,
@@ -839,7 +834,7 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// As a member, retire and back to an ordinary account and unlock its deposit.
+		/// As a member, retire from the alliance and unreserve the deposit.
 		#[pallet::weight(T::WeightInfo::retire())]
 		pub fn retire(origin: OriginFor<T>) -> DispatchResult {
 			let who = ensure_signed(origin)?;
@@ -856,7 +851,7 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Kick a member to ordinary account with its deposit slashed.
+		/// Kick a member from the alliance and slash its deposit.
 		#[pallet::weight(T::WeightInfo::kick_member())]
 		pub fn kick_member(
 			origin: OriginFor<T>,
@@ -876,7 +871,7 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Add accounts or websites into blacklist.
+		/// Add accounts or websites to the blacklist.
 		#[pallet::weight(T::WeightInfo::add_blacklist(infos.len() as u32, T::MaxWebsiteUrlLength::get()))]
 		pub fn add_blacklist(
 			origin: OriginFor<T>,
@@ -905,7 +900,7 @@ pub mod pallet {
 			Ok(())
 		}
 
-		/// Remove accounts or websites from blacklist.
+		/// Remove accounts or websites from the blacklist.
 		#[pallet::weight(<T as Config<I>>::WeightInfo::remove_blacklist(infos.len() as u32, T::MaxWebsiteUrlLength::get()))]
 		pub fn remove_blacklist(
 			origin: OriginFor<T>,
@@ -954,10 +949,12 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		})
 	}
 
+	/// Check if a given role has any members.
 	fn has_member(role: MemberRole) -> bool {
 		Members::<T, I>::decode_len(role).unwrap_or_default() > 0
 	}
 
+	/// Look up the role, if any, of an account.
 	fn member_role_of(who: &T::AccountId) -> Option<MemberRole> {
 		Members::<T, I>::iter()
 			.find_map(|(r, members)| if members.contains(who) { Some(r) } else { None })
@@ -968,26 +965,32 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Self::member_role_of(who).is_some()
 	}
 
+	/// Check if an account has a given role.
 	pub fn is_member_of(who: &T::AccountId, role: MemberRole) -> bool {
 		Members::<T, I>::get(role).contains(&who)
 	}
 
+	/// Check if an account is a founder.
 	fn is_founder(who: &T::AccountId) -> bool {
 		Self::is_member_of(who, MemberRole::Founder)
 	}
 
+	/// Check if an account is a fellow.
 	fn is_fellow(who: &T::AccountId) -> bool {
 		Self::is_member_of(who, MemberRole::Fellow)
 	}
 
+	/// Check if an account is an ally.
 	fn is_ally(who: &T::AccountId) -> bool {
 		Self::is_member_of(who, MemberRole::Ally)
 	}
 
+	/// Check if a member has voting rights.
 	fn is_votable_member(who: &T::AccountId) -> bool {
 		Self::is_founder(who) || Self::is_fellow(who)
 	}
 
+	/// Collect all members who have voting rights into one list.
 	fn votable_member_sorted() -> Vec<T::AccountId> {
 		let mut founders = Members::<T, I>::get(MemberRole::Founder).into_inner();
 		let mut fellows = Members::<T, I>::get(MemberRole::Fellow).into_inner();
@@ -996,6 +999,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		founders.into()
 	}
 
+	/// Check if an account's membership is up for consideration.
 	fn is_kicking(who: &T::AccountId) -> bool {
 		<KickingMembers<T, I>>::contains_key(&who)
 	}
@@ -1032,7 +1036,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Ok(())
 	}
 
-	/// Check if a user is in blacklist.
+	/// Check if an item is blacklisted.
 	fn is_blacklist(info: &BlacklistItemOf<T, I>) -> bool {
 		match info {
 			BlacklistItem::Website(url) => <WebsiteBlacklist<T, I>>::get().contains(url),
@@ -1040,12 +1044,12 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		}
 	}
 
-	/// Check if a user is in account blacklist.
+	/// Check if a user is blacklisted.
 	fn is_account_blacklist(who: &T::AccountId) -> bool {
 		<AccountBlacklist<T, I>>::get().contains(who)
 	}
 
-	/// Add a identity info to the blacklist set.
+	/// Add identity info to the blacklist set.
 	fn do_add_blacklist(
 		new_accounts: &mut Vec<T::AccountId>,
 		new_webs: &mut Vec<UrlOf<T, I>>,
@@ -1070,7 +1074,7 @@ impl<T: Config<I>, I: 'static> Pallet<T, I> {
 		Ok(())
 	}
 
-	/// Remove a identity info from the blacklist.
+	/// Remove identity info from the blacklist.
 	fn do_remove_blacklist(
 		out_accounts: &mut Vec<T::AccountId>,
 		out_webs: &mut Vec<UrlOf<T, I>>,

--- a/frame/alliance/src/tests.rs
+++ b/frame/alliance/src/tests.rs
@@ -457,7 +457,7 @@ fn kick_member_works() {
 	new_test_ext().execute_with(|| {
 		assert_noop!(
 			Alliance::kick_member(Origin::signed(1), 2),
-			Error::<Test, ()>::NotKickingMember
+			Error::<Test, ()>::NotUpForKicking
 		);
 
 		let proposal = make_kick_member_proposal(2);
@@ -468,7 +468,7 @@ fn kick_member_works() {
 			Box::new(proposal.clone()),
 			proposal_len
 		));
-		assert_eq!(Alliance::kicking_member(2), true);
+		assert_eq!(Alliance::up_for_kicking(2), true);
 		assert_eq!(Alliance::members(MemberRole::Founder), vec![1, 2]);
 
 		assert_ok!(Alliance::kick_member(Origin::signed(1), 2));

--- a/frame/alliance/src/tests.rs
+++ b/frame/alliance/src/tests.rs
@@ -286,12 +286,12 @@ fn submit_candidacy_works() {
 		);
 
 		// check already in blacklist
-		assert_ok!(Alliance::add_blacklist(Origin::signed(1), vec![BlacklistItem::AccountId(4)]));
+		assert_ok!(Alliance::add_blacklist_items(Origin::signed(1), vec![BlacklistItem::AccountId(4)]));
 		assert_noop!(
 			Alliance::submit_candidacy(Origin::signed(4)),
 			Error::<Test, ()>::AlreadyInBlacklist
 		);
-		assert_ok!(Alliance::remove_blacklist(
+		assert_ok!(Alliance::remove_blacklist_items(
 			Origin::signed(1),
 			vec![BlacklistItem::AccountId(4)]
 		));
@@ -329,39 +329,39 @@ fn submit_candidacy_works() {
 }
 
 #[test]
-fn nominate_candidacy_works() {
+fn nominate_candidate_works() {
 	new_test_ext().execute_with(|| {
 		// check already member
 		assert_noop!(
-			Alliance::nominate_candidacy(Origin::signed(1), 2),
+			Alliance::nominate_candidate(Origin::signed(1), 2),
 			Error::<Test, ()>::AlreadyMember
 		);
 
 		// only votable member(founder/fellow) have nominate right
 		assert_noop!(
-			Alliance::nominate_candidacy(Origin::signed(5), 4),
+			Alliance::nominate_candidate(Origin::signed(5), 4),
 			Error::<Test, ()>::NotVotableMember
 		);
 
 		// check already in blacklist
-		assert_ok!(Alliance::add_blacklist(Origin::signed(1), vec![BlacklistItem::AccountId(4)]));
+		assert_ok!(Alliance::add_blacklist_items(Origin::signed(1), vec![BlacklistItem::AccountId(4)]));
 		assert_noop!(
-			Alliance::nominate_candidacy(Origin::signed(1), 4),
+			Alliance::nominate_candidate(Origin::signed(1), 4),
 			Error::<Test, ()>::AlreadyInBlacklist
 		);
-		assert_ok!(Alliance::remove_blacklist(
+		assert_ok!(Alliance::remove_blacklist_items(
 			Origin::signed(1),
 			vec![BlacklistItem::AccountId(4)]
 		));
 
 		// success to nominate
-		assert_ok!(Alliance::nominate_candidacy(Origin::signed(1), 4));
+		assert_ok!(Alliance::nominate_candidate(Origin::signed(1), 4));
 		assert_eq!(Alliance::deposit_of(4), None);
 		assert_eq!(Alliance::candidates(), vec![4]);
 
 		// check already candidate
 		assert_noop!(
-			Alliance::nominate_candidacy(Origin::signed(1), 4),
+			Alliance::nominate_candidate(Origin::signed(1), 4),
 			Error::<Test, ()>::AlreadyCandidate
 		);
 
@@ -477,9 +477,9 @@ fn kick_member_works() {
 }
 
 #[test]
-fn add_blacklist_works() {
+fn add_blacklist_items_works() {
 	new_test_ext().execute_with(|| {
-		assert_ok!(Alliance::add_blacklist(
+		assert_ok!(Alliance::add_blacklist_items(
 			Origin::signed(1),
 			vec![
 				BlacklistItem::AccountId(3),
@@ -490,23 +490,23 @@ fn add_blacklist_works() {
 		assert_eq!(Alliance::website_blacklist().into_inner(), vec!["abc".as_bytes().to_vec()]);
 
 		assert_noop!(
-			Alliance::add_blacklist(Origin::signed(1), vec![BlacklistItem::AccountId(3)]),
+			Alliance::add_blacklist_items(Origin::signed(1), vec![BlacklistItem::AccountId(3)]),
 			Error::<Test, ()>::AlreadyInBlacklist
 		);
 	});
 }
 
 #[test]
-fn remove_blacklist_works() {
+fn remove_blacklist_items_works() {
 	new_test_ext().execute_with(|| {
 		assert_noop!(
-			Alliance::remove_blacklist(Origin::signed(1), vec![BlacklistItem::AccountId(3)]),
+			Alliance::remove_blacklist_items(Origin::signed(1), vec![BlacklistItem::AccountId(3)]),
 			Error::<Test, ()>::NotInBlacklist
 		);
 
-		assert_ok!(Alliance::add_blacklist(Origin::signed(1), vec![BlacklistItem::AccountId(3)]));
+		assert_ok!(Alliance::add_blacklist_items(Origin::signed(1), vec![BlacklistItem::AccountId(3)]));
 		assert_eq!(Alliance::account_blacklist(), vec![3]);
-		assert_ok!(Alliance::remove_blacklist(
+		assert_ok!(Alliance::remove_blacklist_items(
 			Origin::signed(1),
 			vec![BlacklistItem::AccountId(3)]
 		));

--- a/frame/alliance/src/weights.rs
+++ b/frame/alliance/src/weights.rs
@@ -57,14 +57,14 @@ pub trait WeightInfo {
 	fn announce() -> Weight;
 	fn remove_announcement() -> Weight;
 	fn submit_candidacy() -> Weight;
-	fn nominate_candidacy() -> Weight;
+	fn nominate_candidate() -> Weight;
 	fn approve_candidate() -> Weight;
 	fn reject_candidate() -> Weight;
 	fn elevate_ally() -> Weight;
 	fn retire() -> Weight;
 	fn kick_member() -> Weight;
-	fn add_blacklist(n: u32, l: u32, ) -> Weight;
-	fn remove_blacklist(n: u32, l: u32, ) -> Weight;
+	fn add_blacklist_items(n: u32, l: u32, ) -> Weight;
+	fn remove_blacklist_items(n: u32, l: u32, ) -> Weight;
 }
 
 /// Weights for pallet_alliance using the Substrate node and recommended hardware.
@@ -217,7 +217,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	// Storage: Alliance Members (r:4 w:0)
 	// Storage: Alliance AccountBlacklist (r:1 w:0)
 	// Storage: Alliance Candidates (r:1 w:1)
-	fn nominate_candidacy() -> Weight {
+	fn nominate_candidate() -> Weight {
 		(44_764_000 as Weight)
 			.saturating_add(T::DbWeight::get().reads(6 as Weight))
 			.saturating_add(T::DbWeight::get().writes(1 as Weight))
@@ -273,7 +273,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	}
 	// Storage: Alliance AccountBlacklist (r:1 w:1)
 	// Storage: Alliance WebsiteBlacklist (r:1 w:1)
-	fn add_blacklist(n: u32, l: u32, ) -> Weight {
+	fn add_blacklist_items(n: u32, l: u32, ) -> Weight {
 		(0 as Weight)
 			// Standard Error: 16_000
 			.saturating_add((2_673_000 as Weight).saturating_mul(n as Weight))
@@ -284,7 +284,7 @@ impl<T: frame_system::Config> WeightInfo for SubstrateWeight<T> {
 	}
 	// Storage: Alliance AccountBlacklist (r:1 w:1)
 	// Storage: Alliance WebsiteBlacklist (r:1 w:1)
-	fn remove_blacklist(n: u32, l: u32, ) -> Weight {
+	fn remove_blacklist_items(n: u32, l: u32, ) -> Weight {
 		(0 as Weight)
 			// Standard Error: 343_000
 			.saturating_add((59_025_000 as Weight).saturating_mul(n as Weight))
@@ -444,7 +444,7 @@ impl WeightInfo for () {
 	// Storage: Alliance Members (r:4 w:0)
 	// Storage: Alliance AccountBlacklist (r:1 w:0)
 	// Storage: Alliance Candidates (r:1 w:1)
-	fn nominate_candidacy() -> Weight {
+	fn nominate_candidate() -> Weight {
 		(44_764_000 as Weight)
 			.saturating_add(RocksDbWeight::get().reads(6 as Weight))
 			.saturating_add(RocksDbWeight::get().writes(1 as Weight))
@@ -500,7 +500,7 @@ impl WeightInfo for () {
 	}
 	// Storage: Alliance AccountBlacklist (r:1 w:1)
 	// Storage: Alliance WebsiteBlacklist (r:1 w:1)
-	fn add_blacklist(n: u32, l: u32, ) -> Weight {
+	fn add_blacklist_items(n: u32, l: u32, ) -> Weight {
 		(0 as Weight)
 			// Standard Error: 16_000
 			.saturating_add((2_673_000 as Weight).saturating_mul(n as Weight))
@@ -511,7 +511,7 @@ impl WeightInfo for () {
 	}
 	// Storage: Alliance AccountBlacklist (r:1 w:1)
 	// Storage: Alliance WebsiteBlacklist (r:1 w:1)
-	fn remove_blacklist(n: u32, l: u32, ) -> Weight {
+	fn remove_blacklist_items(n: u32, l: u32, ) -> Weight {
 		(0 as Weight)
 			// Standard Error: 343_000
 			.saturating_add((59_025_000 as Weight).saturating_mul(n as Weight))


### PR DESCRIPTION
I split this into two commits:

1. Documentation, this commit should be fairly uncontroversial, just tried to make the docs clearer and did not touch any logic.
2. Renaming, this is more opinionated, but I:
    - Renamed events/errors to be clearer and adhere to past participles for events.
    - Changed some function APIs to better convey their operations.
    - Added new origins and removed "super majority" naming, as it's set in the runtime configuration of the pallet, and someone might not configure it as a super majority.